### PR TITLE
optimized firefly rendering

### DIFF
--- a/src/Fireflies/VideoMaker.php
+++ b/src/Fireflies/VideoMaker.php
@@ -10,7 +10,7 @@ class VideoMaker
     {
         @unlink(self::OUTPUT_FILE_NAME);
         $command = sprintf(
-            'ffmpeg -f image2 -framerate %s -i %s -loop -1 %s 2>&1',
+            'ffmpeg -f image2 -framerate %s -i %s %s 2>&1',
             $fps,
             sprintf($swarmRenderer->getFrameNamePattern(), "%" . $swarmRenderer::FRAME_NAME_LENGTH . "d"),
             self::OUTPUT_FILE_NAME


### PR DESCRIPTION
Before (with 10x shorter simulation):
```
$ time bin/console fireflies:render
Creating swarm...
Running simulation...
Making pretty video...
All done! Your video is stored in fireflies.gif

real	2m41.733s
user	2m41.960s
sys	0m1.070s
```

After (with 10x shorter simulation):
```
$ time bin/console fireflies:render
Creating swarm...
Running simulation...
Making pretty video...
All done! Your video is stored in fireflies.gif

real	0m14.550s
user	0m14.982s
sys	0m1.094s
```
The substance of the fix is that calculating mask for firefly image is done once per shine level and cached

![fireflies](https://user-images.githubusercontent.com/925376/209678503-d4516a4a-1dc4-4e02-b40a-7c9c6aa25ae4.gif)

